### PR TITLE
Fixing ER #7

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.11-bookworm
+FROM python:3.12-alpine
 
 COPY . /log-generator
 RUN cd /log-generator &&\


### PR DESCRIPTION
Switching to alpine base image in docker
- Bookworm :  1.04GB
- Alpine : 85.1M

Took the opportunity to bump to Python 3.12